### PR TITLE
Fix for empty files

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -25,7 +25,7 @@ function generateAll (descriptor) {
 		statements : {
 			total : 0,
 			covered : 0,
-			percentage : 0
+			percentage : 100
 		},
 		conditions : {
 			total : 0,
@@ -137,7 +137,7 @@ function statementCoverage (allLines, coveredLines) {
 		total : allLines.length,
 		covered : covered,
 		detail : coveredLines,
-		percentage : 100.0 * covered / allLines.length
+		percentage : allLines.length == 0 ? 100 : 100.0 * covered / allLines.length
 	};
 };
 
@@ -207,7 +207,7 @@ function mergeReports (reports) {
 			statements : {
 				total : 0,
 				covered : 0,
-				percentage : 0
+				percentage : 100
 			},
 			conditions : {
 				total : 0,


### PR DESCRIPTION
This commit fixes the following issue: having an empty file in the set of files to be instrumented can later prevent the whole report from being displayed, because of the division by zero which results in a null value in the report.
